### PR TITLE
Adding -Wl,-rpath FULLPATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 env:
-  - PACKSODIR=lib CFLAGS='-fPIC -pthread -I"/usr/local/lib/swipl/include" -I"/usr/lib/swipl/include"' SOEXT='so' CC=gcc
+  - PACKSODIR=lib CFLAGS='-fPIC -pthread -I"/usr/lib/swipl-prolog/include"' SOEXT='so' CC=gcc
 
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: rust
 
 env:
-  - PACKSODIR=lib
-  - CFLAGS='-fPIC -pthread -I"/usr/local/lib/swipl/include" -I"/usr/lib/swipl/include"'
-  - SOEXT='so'
-  - CC=gcc
+  - PACKSODIR=lib CFLAGS='-fPIC -pthread -I"/usr/local/lib/swipl/include" -I"/usr/lib/swipl/include"' SOEXT='so' CC=gcc
 
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
 
+env:
+  - PACKSODIR=lib
+  - CFLAGS='-fPIC -pthread -I"/usr/local/lib/swipl/include" -I"/usr/lib/swipl/include"'
+  - SOEXT='so'
+  - CC=gcc
+
 rust:
   - stable
 
@@ -9,7 +15,7 @@ before_script:
   - sudo apt-get install swi-prolog-nox autoconf libtool build-essential
 
 script:
-  - make
+  - PACKSODIR='make
   - swipl -g run_tests -g halt ./prolog/terminus_store.pl
   - swipl -g "show_coverage(run_tests)." -g halt prolog/terminus_store.pl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - sudo apt-get install swi-prolog-nox autoconf libtool build-essential
 
 script:
-  - PACKSODIR='make
+  - make
   - swipl -g run_tests -g halt ./prolog/terminus_store.pl
   - swipl -g "show_coverage(run_tests)." -g halt prolog/terminus_store.pl
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-INCLUDES = -I/usr/lib/swi-prolog/include -I/usr/local/lib/swipl/include
-CC = gcc
-CFLAGS = -shared -fpic -Wall
+RUST_LIB_NAME = terminus_store_prolog
+RUST_LIB = lib$(RUST_LIB_NAME).$(SOEXT)
 RUST_TARGET=release
-RUST_LIB = rust/target/$(RUST_TARGET)/libterminus_store_prolog.so
-TARGET = libterminus_store.so
+RUST_SOURCE_PATH = rust/target/$(RUST_TARGET)/$(RUST_LIB)
+TARGET = $(PACKSODIR)/libterminus_store.$(SOEXT)
 
 all: build
 
@@ -13,14 +12,19 @@ rust_bindings:
 check::
 
 build:
+	mkdir -p $(PACKSODIR)
 	cd rust; cargo build --$(RUST_TARGET)
-	$(CC) $(CFLAGS) -o $(TARGET) ./c/*.c -Isrc -L. -l:./$(RUST_LIB) $(INCLUDES)
+	mv $(RUST_SOURCE_PATH) ./$(PACKSODIR)
+	$(CC) -shared $(CFLAGS) -o $(TARGET) ./c/*.c -Isrc -L./$(PACKSODIR) -Wl,-rpath $(CURDIR)/$(PACKSODIR) -l$(RUST_LIB_NAME)
 
 debug: RUST_TARGET = debug
 debug: CFLAGS += -ggdb
 debug:
+	mkdir -p $(PACKSODIR)
 	cd rust; cargo build
-	$(CC) $(CFLAGS) -o $(TARGET) ./c/*.c -Isrc -L. -l:./$(RUST_LIB) $(INCLUDES)
+	mv $(RUST_SOURCE_PATH) ./$(PACKSODIR)
+	$(CC) -shared $(CFLAGS) -o $(TARGET) ./c/*.c -Isrc -L./$(PACKSODIR) -Wl,-rpath $(CURDIR)/$(PACKSODIR) -l$(RUST_LIB_NAME)
+
 
 install::
 

--- a/prolog/terminus_store.pl
+++ b/prolog/terminus_store.pl
@@ -24,7 +24,7 @@
               triple/4
           ]).
 
-:- use_foreign_library(libterminus_store).
+:- use_foreign_library(foreign(libterminus_store)).
 
 /*
  * nb_add_triple(+Builder, +Subject, +Predicate, +Object) is semidet


### PR DESCRIPTION
I was having trouble with the shared object for prolog pointing at the shared object for rust. It appeared to work only if I invoked swipl from the build directory. 

Since the cargo produces a shared object, and in the swipl-pack this is always linked by another shared object which is subsequently loaded by prolog, the general fact of -Wl,-rpath being evil might be trumped by the convenience of just providing the full path the loaded shared object.  I'm open to other suggestions.

Other than that I refer to more of the variables from the build environment set up by swipl. 