### PR TITLE
implement imprecise_rollup_upto in the prolog library, and fix existing implementation

### DIFF
--- a/c/terminus_store.c
+++ b/c/terminus_store.c
@@ -646,6 +646,23 @@ static foreign_t pl_layer_rollup_upto(term_t layer_term, term_t upto_term) {
     PL_succeed;
 }
 
+static foreign_t pl_layer_imprecise_rollup_upto(term_t layer_term, term_t upto_term) {
+    void* layer = check_blob_type(layer_term, &layer_blob_type);
+    void* upto = check_blob_type(upto_term, &layer_blob_type);
+
+    if (PL_is_variable(layer_term)
+        || PL_is_variable(upto_term)) {
+        return throw_instantiation_err(layer_term);
+    }
+
+    char* err;
+    layer_imprecise_rollup_upto(layer, upto, &err);
+    if (err != NULL) {
+        return throw_rust_err(err);
+    }
+    PL_succeed;
+}
+
 static foreign_t pl_layer_addition_count(term_t layer_term, term_t count_term) {
     void* layer = check_blob_type(layer_term, &layer_blob_type);
 
@@ -1492,6 +1509,8 @@ install()
                         pl_layer_rollup, 0);
     PL_register_foreign("rollup_upto", 2,
                         pl_layer_rollup_upto, 0);
+    PL_register_foreign("imprecise_rollup_upto", 2,
+                        pl_layer_imprecise_rollup_upto, 0);
     PL_register_foreign("layer_addition_count", 2,
                         pl_layer_addition_count, 0);
     PL_register_foreign("layer_removal_count", 2,

--- a/c/terminus_store.h
+++ b/c/terminus_store.h
@@ -1,6 +1,17 @@
 #include <stdbool.h>
 
 typedef struct {
+  void *ptr;
+  uintptr_t len;
+  uintptr_t capacity;
+} VecHandle;
+
+typedef struct {
+  uint64_t subject;
+  uint64_t predicate;
+} SubjectPredicatePair;
+
+typedef struct {
   uint64_t first;
   uint64_t second;
 } U64Pair;
@@ -12,47 +23,20 @@ typedef struct {
 } U64Triple;
 
 typedef struct {
-  uint64_t subject;
-  uint64_t predicate;
-} SubjectPredicatePair;
-
-typedef struct {
-  void *ptr;
-  uintptr_t len;
-  uintptr_t capacity;
-} VecHandle;
-
-typedef struct {
   uint32_t layer_id[5];
   uint32_t layer_parent_id[5];
   bool has_parent;
 } LayerAndParent;
 
-void *open_memory_store(void);
-
-void *open_directory_store(char *dir);
-
-void *create_named_graph(void *store_ptr, char *name, char **err);
-
-void *open_named_graph(void *store, char *name, char **err);
-
-char *named_graph_get_name(void *named_graph);
-
-void *named_graph_get_head(void *named_graph, char **err);
-
-bool named_graph_set_head(void *named_graph, void *layer_ptr, char **err);
-
-bool named_graph_force_set_head(void *named_graph, void *layer_ptr, char **err);
-
-void *store_create_base_layer(void *store, char **err);
-
-char *layer_builder_get_id(void *builder);
-
-char *layer_get_id(void *layer);
-
-void *layer_open_write(void *layer, char **err);
-
-void *named_graph_open_write(void *named_graph, char **err);
+void add_csv_to_builder(char *name,
+                        char *csv,
+                        void *builder,
+                        void *schema_builder,
+                        char *data_prefix,
+                        char *predicate_prefix,
+                        int header,
+                        int skip_header,
+                        char **err);
 
 void builder_add_id_triple(void *builder,
                            uint64_t subject,
@@ -72,6 +56,14 @@ void builder_add_string_value_triple(void *builder,
                                      char *object_ptr,
                                      char **err);
 
+void builder_apply_delta(void *builder, void *layer, char **err);
+
+void builder_apply_diff(void *builder, void *layer, char **err);
+
+void *builder_commit(void *builder, char **err);
+
+bool builder_committed(void *builder);
+
 void builder_remove_id_triple(void *builder,
                               uint64_t subject,
                               uint64_t predicate,
@@ -90,61 +82,47 @@ void builder_remove_string_value_triple(void *builder,
                                         char *object_ptr,
                                         char **err);
 
-bool builder_committed(void *builder);
+void cleanup_cstring(char *cstring_ptr);
 
-void *builder_commit(void *builder, char **err);
+void cleanup_db(void *db);
 
-void builder_apply_delta(void *builder, void *layer, char **err);
+void cleanup_layer(void *layer);
 
-void builder_apply_diff(void *builder, void *layer, char **err);
+void cleanup_layer_and_parent_vec(VecHandle vec_handle);
 
-void *layer_parent(void *layer, char **err);
+void cleanup_layer_builder(void *layer_builder);
 
-void *layer_squash(void *layer, char **err);
+void cleanup_layer_vec(VecHandle vec_handle);
 
-uintptr_t layer_node_and_value_count(void *layer);
+void cleanup_object_subject_predicates_iter(void *iter);
 
-uintptr_t layer_predicate_count(void *layer);
+void cleanup_store(void *store);
 
-uint64_t layer_subject_id(void *layer, char *subject);
+void cleanup_subject_predicate_objects_iter(void *iter);
 
-uint64_t layer_predicate_id(void *layer, char *predicate);
+void cleanup_u64_iter(void *iter);
 
-uint64_t layer_object_node_id(void *layer, char *object);
+void cleanup_u64_pair_iter(void *iter);
 
-uint64_t layer_object_value_id(void *layer, char *object);
+void cleanup_u64_triple_iter(void *iter);
 
-char *layer_id_subject(void *layer, uint64_t id);
+void cleanup_u8_vec(VecHandle vec_handle);
 
-char *layer_id_predicate(void *layer, uint64_t id);
+void *create_named_graph(void *store_ptr, char *name, char **err);
 
-char *layer_id_object(void *layer, uint64_t id, uint8_t *object_type);
+char *csv_iri(const char *csv_name, const char *prefix);
 
-uintptr_t layer_triple_addition_count(void *layer, char **err);
+void *id_triple_addition_iter(void *layer, char **err);
 
-uintptr_t layer_triple_removal_count(void *layer, char **err);
+void *id_triple_addition_o_iter(void *layer, uint64_t object, char **err);
 
-uintptr_t layer_total_triple_addition_count(void *layer);
+void *id_triple_addition_p_iter(void *layer, uint64_t predicate, char **err);
 
-uintptr_t layer_total_triple_removal_count(void *layer);
+void *id_triple_addition_s_iter(void *layer, uint64_t subject, char **err);
 
-uintptr_t layer_total_triple_count(void *layer);
+void *id_triple_addition_so_iter(void *layer, uint64_t subject, uint64_t object, char **err);
 
-uint64_t subject_predicate_objects_iter_next(void *iter);
-
-bool id_triple_spo_exists(void *layer, uint64_t subject, uint64_t predicate, uint64_t object);
-
-void *id_triple_sp_iter(void *layer, uint64_t subject, uint64_t predicate);
-
-void *id_triple_so_iter(void *layer, uint64_t subject, uint64_t object);
-
-void *id_triple_s_iter(void *layer, uint64_t subject);
-
-void *id_triple_p_iter(void *layer, uint64_t predicate);
-
-void *id_triple_o_iter(void *layer, uint64_t object);
-
-void *id_triple_iter(void *layer);
+void *id_triple_addition_sp_iter(void *layer, uint64_t subject, uint64_t predicate, char **err);
 
 bool id_triple_addition_spo_exists(void *layer,
                                    uint64_t subject,
@@ -152,17 +130,23 @@ bool id_triple_addition_spo_exists(void *layer,
                                    uint64_t object,
                                    char **err);
 
-void *id_triple_addition_sp_iter(void *layer, uint64_t subject, uint64_t predicate, char **err);
+void *id_triple_iter(void *layer);
 
-void *id_triple_addition_so_iter(void *layer, uint64_t subject, uint64_t object, char **err);
+void *id_triple_o_iter(void *layer, uint64_t object);
 
-void *id_triple_addition_s_iter(void *layer, uint64_t subject, char **err);
+void *id_triple_p_iter(void *layer, uint64_t predicate);
 
-void *id_triple_addition_p_iter(void *layer, uint64_t predicate, char **err);
+void *id_triple_removal_iter(void *layer, char **err);
 
-void *id_triple_addition_o_iter(void *layer, uint64_t object, char **err);
+void *id_triple_removal_o_iter(void *layer, uint64_t object, char **err);
 
-void *id_triple_addition_iter(void *layer, char **err);
+void *id_triple_removal_p_iter(void *layer, uint64_t predicate, char **err);
+
+void *id_triple_removal_s_iter(void *layer, uint64_t subject, char **err);
+
+void *id_triple_removal_so_iter(void *layer, uint64_t subject, uint64_t object, char **err);
+
+void *id_triple_removal_sp_iter(void *layer, uint64_t subject, uint64_t predicate, char **err);
 
 bool id_triple_removal_spo_exists(void *layer,
                                   uint64_t subject,
@@ -170,31 +154,79 @@ bool id_triple_removal_spo_exists(void *layer,
                                   uint64_t object,
                                   char **err);
 
-void *id_triple_removal_sp_iter(void *layer, uint64_t subject, uint64_t predicate, char **err);
+void *id_triple_s_iter(void *layer, uint64_t subject);
 
-void *id_triple_removal_so_iter(void *layer, uint64_t subject, uint64_t object, char **err);
+void *id_triple_so_iter(void *layer, uint64_t subject, uint64_t object);
 
-void *id_triple_removal_s_iter(void *layer, uint64_t subject, char **err);
+void *id_triple_sp_iter(void *layer, uint64_t subject, uint64_t predicate);
 
-void *id_triple_removal_p_iter(void *layer, uint64_t predicate, char **err);
+bool id_triple_spo_exists(void *layer, uint64_t subject, uint64_t predicate, uint64_t object);
 
-void *id_triple_removal_o_iter(void *layer, uint64_t object, char **err);
+char *layer_builder_get_id(void *builder);
 
-void *id_triple_removal_iter(void *layer, char **err);
+char *layer_get_id(void *layer);
 
-uint64_t u64_iter_next(void *iter);
+char *layer_id_object(void *layer, uint64_t id, uint8_t *object_type);
 
-U64Pair u64_pair_iter_next(void *iter);
+char *layer_id_predicate(void *layer, uint64_t id);
 
-U64Triple u64_triple_iter_next(void *iter);
-
-SubjectPredicatePair object_subject_predicate_pairs_iter_next(void *iter);
-
-void *store_get_layer_from_id(void *store, char *id, char **err);
+char *layer_id_subject(void *layer, uint64_t id);
 
 char *layer_id_to_string(const uint32_t *id);
 
+void layer_imprecise_rollup_upto(void *layer, void *upto, char **err);
+
+uintptr_t layer_node_and_value_count(void *layer);
+
+uint64_t layer_object_node_id(void *layer, char *object);
+
+uint64_t layer_object_value_id(void *layer, char *object);
+
+void *layer_open_write(void *layer, char **err);
+
+void *layer_parent(void *layer, char **err);
+
+uintptr_t layer_predicate_count(void *layer);
+
+uint64_t layer_predicate_id(void *layer, char *predicate);
+
+void layer_rollup(void *layer, char **err);
+
+void layer_rollup_upto(void *layer, void *upto, char **err);
+
+void *layer_squash(void *layer, char **err);
+
 bool layer_string_to_id(const char *name_ptr, uint32_t (*result)[5], char **err);
+
+uint64_t layer_subject_id(void *layer, char *subject);
+
+uintptr_t layer_total_triple_addition_count(void *layer);
+
+uintptr_t layer_total_triple_count(void *layer);
+
+uintptr_t layer_total_triple_removal_count(void *layer);
+
+uintptr_t layer_triple_addition_count(void *layer, char **err);
+
+uintptr_t layer_triple_removal_count(void *layer, char **err);
+
+bool named_graph_force_set_head(void *named_graph, void *layer_ptr, char **err);
+
+void *named_graph_get_head(void *named_graph, char **err);
+
+char *named_graph_get_name(void *named_graph);
+
+void *named_graph_open_write(void *named_graph, char **err);
+
+bool named_graph_set_head(void *named_graph, void *layer_ptr, char **err);
+
+SubjectPredicatePair object_subject_predicate_pairs_iter_next(void *iter);
+
+void *open_directory_store(char *dir);
+
+void *open_memory_store(void);
+
+void *open_named_graph(void *store, char *name, char **err);
 
 VecHandle pack_export(void *store, const uint32_t (*layer_ids_ptr)[5], uintptr_t layer_ids_len);
 
@@ -207,46 +239,16 @@ void pack_import(void *store,
 
 VecHandle pack_layerids_and_parents(const uint8_t *pack_ptr, uintptr_t pack_len, char **err);
 
-void cleanup_store(void *store);
-
-void cleanup_db(void *db);
-
-void cleanup_layer(void *layer);
-
-void cleanup_layer_builder(void *layer_builder);
-
-void cleanup_subject_predicate_objects_iter(void *iter);
-
-void cleanup_object_subject_predicates_iter(void *iter);
-
-void cleanup_u64_triple_iter(void *iter);
-
-void cleanup_u64_pair_iter(void *iter);
-
-void cleanup_u64_iter(void *iter);
-
-void cleanup_cstring(char *cstring_ptr);
-
-void cleanup_u8_vec(VecHandle vec_handle);
-
-void cleanup_layer_and_parent_vec(VecHandle vec_handle);
-
-void cleanup_layer_vec(VecHandle vec_handle);
-
-void add_csv_to_builder(char *name,
-                        char *csv,
-                        void *builder,
-                        void *schema_builder,
-                        char *data_prefix,
-                        char *predicate_prefix,
-                        int header,
-                        int skip_header,
-                        char **err);
-
-char *csv_iri(const char *csv_name, const char *prefix);
-
-void layer_rollup(void *layer, char **err);
-
-void layer_rollup_upto(void *layer, void *upto, char **err);
-
 VecHandle retrieve_layer_stack_names(void *layer, char **err);
+
+void *store_create_base_layer(void *store, char **err);
+
+void *store_get_layer_from_id(void *store, char *id, char **err);
+
+uint64_t subject_predicate_objects_iter_next(void *iter);
+
+uint64_t u64_iter_next(void *iter);
+
+U64Pair u64_pair_iter_next(void *iter);
+
+U64Triple u64_triple_iter_next(void *iter);

--- a/prolog/terminus_store.pl
+++ b/prolog/terminus_store.pl
@@ -57,8 +57,8 @@
               count_layer_stack_size/2,
 
               rollup/1,
-
               rollup_upto/2,
+              imprecise_rollup_upto/2,
 
               layer_stack_names/2
             ]).

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ name = "terminus_store_prolog"
 crate-type = ["staticlib"]
 
 [dependencies]
-terminus-store = "=0.16.4"
+terminus-store = "=0.17.1"
 csv = "1.1"
 rayon = "1.4"
 clap = "2.33.3"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1276,7 +1276,6 @@ pub unsafe extern "C" fn cleanup_layer_vec(vec_handle: VecHandle) {
     );
 }
 
-
 #[no_mangle]
 pub unsafe extern "C" fn add_csv_to_builder(
     name: *mut c_char,
@@ -1347,10 +1346,26 @@ pub unsafe extern "C" fn layer_rollup(layer: *mut SyncStoreLayer, err: *mut *mut
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn layer_rollup_upto(layer: *mut SyncStoreLayer,
-                                           upto: *mut SyncStoreLayer,
-                                           err: *mut *mut c_char) {
+pub unsafe extern "C" fn layer_rollup_upto(
+    layer: *mut SyncStoreLayer,
+    upto: *mut SyncStoreLayer,
+    err: *mut *mut c_char,
+) {
     match (*layer).rollup_upto(&*upto) {
+        Ok(()) => *err = std::ptr::null_mut(),
+        Err(e) => {
+            *err = error_to_cstring(e).into_raw();
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn layer_imprecise_rollup_upto(
+    layer: *mut SyncStoreLayer,
+    upto: *mut SyncStoreLayer,
+    err: *mut *mut c_char,
+) {
+    match (*layer).imprecise_rollup_upto(&*upto) {
         Ok(()) => *err = std::ptr::null_mut(),
         Err(e) => {
             *err = error_to_cstring(e).into_raw();
@@ -1361,9 +1376,9 @@ pub unsafe extern "C" fn layer_rollup_upto(layer: *mut SyncStoreLayer,
 #[no_mangle]
 pub unsafe extern "C" fn retrieve_layer_stack_names(
     layer: *mut SyncStoreLayer,
-    err: *mut *mut c_char) -> VecHandle
-{
-    match (* layer).retrieve_layer_stack_names() {
+    err: *mut *mut c_char,
+) -> VecHandle {
+    match (*layer).retrieve_layer_stack_names() {
         Ok(mut names) => {
             let len = names.len();
             let capacity = names.capacity();


### PR DESCRIPTION
This pulls in the new version of terminus-store with fixes, and exposes the new imprecise_rollup_upto as a prolog predicate.