### PR TITLE
prolog: add missing imported libraries

### DIFF
--- a/prolog/terminus_store.pl
+++ b/prolog/terminus_store.pl
@@ -70,6 +70,11 @@
 
 :- use_foreign_library(foreign(libterminus_store)).
 
+:- use_module(library(lists)).
+:- use_module(library(option)).
+:- use_module(library(plunit)).
+:- use_module(library(random)).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% pldocs for the foreign predicates %%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
They were not added because we relied on autoloading being able to find those predicates.

Predicates that were used but not imported:

- member
- random
- option
- all the test stuff from plunit
- perhaps some I missed?