### PR TITLE
Update scripts: disable autoload, exit on error

### DIFF
--- a/script/swipl-cmd.sh
+++ b/script/swipl-cmd.sh
@@ -8,12 +8,16 @@ PACKSODIR="lib/$($SCRIPTDIR/swiarch.pl)"
 # Top-level directory
 TOPDIR="$SCRIPTDIR/.."
 
-# Run `swipl`, add the shared library to the search path, and `consult/1` the
-# Prolog.
+# Run `swipl`, disable autoloading (to report implicit imports), add the shared
+# library to the search path, and `consult/1` the Prolog.
 CMD=(swipl
+  --on-error=status
+  -g "set_prolog_flag(autoload, false)"
   -g "asserta(file_search_path(foreign,'$TOPDIR/$PACKSODIR'))"
   -g "['$TOPDIR/prolog/terminus_store.pl']"
   -g version
   "$@")
+
+# Note: The --on-error flag requires a SWI-Prolog version >= 8.4.
 
 # Use the above array by calling "${CMD[@]}".

--- a/script/test
+++ b/script/test
@@ -18,4 +18,4 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && (cygpath --mixe
 source "$SCRIPTDIR/swipl-cmd.sh"
 
 # Run the `swipl` command with tests
-"${CMD[@]}" -g run_tests -g halt
+"${CMD[@]}" -g terminus_store:run_tests -g halt


### PR DESCRIPTION
I was concerned about preventing regressions in module importing that lead to
#34, so I modified the scripts used to run tests. CI would now fail with
e35ed735cfd3b3674cb27eba54fdea550abf323d (before #34 was merged).
